### PR TITLE
错误日志里，errorname 重叠

### DIFF
--- a/lib/multi_redis.js
+++ b/lib/multi_redis.js
@@ -18,12 +18,15 @@ var commands = require('./commands');
  * @return {Error}
  */
 function mError(msg) {
+  var err;
   if (msg instanceof Error) {
-    msg.name = 'MRedis' + msg.name;
-    return msg;
+    err = new Error(msg.message);
+    err.stack = msg.stack;
+    err.name = 'MRedis' + msg.name;
+  } else {
+    err = new Error(msg);
+    err.name = 'MRedisError';
   }
-  var err = new Error(msg);
-  err.name = 'MRedisError';
   return err;
 }
 


### PR DESCRIPTION
``` log
[MRedisError: Redis connection gone from end event.] }
[MRedisMRedisError: Redis connection gone from end event.]}
[MRedisMRedisMRedisError: Redis connection gone from end event.]}
[MRedisMRedisMRedisMRedisError: Redis connection gone from end event.]}
[MRedisMRedisMRedisMRedisMRedisError: Redis connection gone from end event.]
```

有映像把？  之前的代码里， err对象传进来， 会直接叠加  Mredis + Err.name， 

当ping动作n+ 次不通时， mredis执行了 client.end() ， 这个时候，假如有5个callback在排队， 那么每个callback被执行的时候，
都会被加  Mredis， 就导致了上面的错误日志输出。

连带发现更糟糕的问题是， redis 模块的命令是串行的， 一旦执行有一个命令阻塞， 有可能ping不通，从而导致client链接重置。
所以有些场景可能还需要启用连接池来处理这种场景。

终于了结了一个心结，哈哈哈
